### PR TITLE
Package name git-core deprecated in RHEL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,15 @@
 #  class { 'git': }
 #
 class git {
-  package { 'git-core':
+
+  $gitpkg = $::osfamily ? {
+    'RedHat' => 'git',
+    'Debian' => 'git-core',
+  }
+
+  package { $gitpkg:
     ensure => installed,
   }
 }
+
+# vim: set ts=2 sw=2 et ft=puppet:


### PR DESCRIPTION
I am unsure if the package name is still valid in Debian land. I've added a selector based on the osfamily fact.
