### PR TITLE
add version for vcsrepo dependency

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -6,5 +6,5 @@ license 'Apache 2.0'
 summary 'module for installing git'
 description 'module for installing git'
 project_page 'https://github.com/puppetlabs/puppetlabs-git/'
-dependency 'puppetlabs/vcsrepo'
+dependency 'puppetlabs/vcsrepo', '>=0.1.0'
 


### PR DESCRIPTION
librarian-puppet 0.9.10 failed to install required dependency with backtrace:

```
    /usr/local/share/gems/gems/librarian-puppet-0.9.10/lib/librarian/puppet/requirement.rb:23:in `range_requirement?': undefined method `match' for nil:NilClass (NoMethodError)
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/lib/librarian/puppet/requirement.rb:11:in `gem_requirement'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/lib/librarian/puppet/source/git.rb:103:in `block in fetch_dependencies'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/lib/librarian/puppet/source/git.rb:102:in `each'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/lib/librarian/puppet/source/git.rb:102:in `map'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/lib/librarian/puppet/source/git.rb:102:in `fetch_dependencies'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/manifest.rb:215:in `fetch_dependencies!'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/manifest.rb:207:in `fetched_dependencies'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/manifest.rb:171:in `dependencies'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/resolver/implementation.rb:67:in `block (4 levels) in recursive_resolve'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/resolver/implementation.rb:103:in `scope'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/resolver/implementation.rb:64:in `block (3 levels) in recursive_resolve'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/resolver/implementation.rb:60:in `each'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/resolver/implementation.rb:60:in `block (2 levels) in recursive_resolve'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/resolver/implementation.rb:103:in `scope'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/resolver/implementation.rb:59:in `block in recursive_resolve'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/resolver/implementation.rb:103:in `scope'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/resolver/implementation.rb:42:in `recursive_resolve'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/resolver.rb:18:in `resolve'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/action/resolve.rb:25:in `run'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/cli.rb:161:in `resolve!'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/lib/librarian/puppet/cli.rb:63:in `install'
    from /usr/local/share/gems/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    from /usr/local/share/gems/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /usr/local/share/gems/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
    from /usr/local/share/gems/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/vendor/librarian/lib/librarian/cli.rb:29:in `bin!'
    from /usr/local/share/gems/gems/librarian-puppet-0.9.10/bin/librarian-puppet:9:in `<top (required)>'
    from /usr/local/bin/librarian-puppet:23:in `load'
    from /usr/local/bin/librarian-puppet:23:in `<main>'
```

it can be fixed by add version for vcsrepo dependency.
