### PR TITLE
Add params to support suse and disable support of non-redhat for gitosis

### DIFF
--- a/manifests/gitosis.pp
+++ b/manifests/gitosis.pp
@@ -5,9 +5,7 @@
 # Requires:
 #  - Class[git]
 #
-class git::gitosis {
+class git::gitosis inherits gitosis::params {
   include ::git
-  package {'gitosis':
-    ensure => present
-  }
+  package { $package: ensure => present }
 }

--- a/manifests/gitosis/params.pp
+++ b/manifests/gitosis/params.pp
@@ -1,0 +1,6 @@
+class gitosis::params() {
+  case $::osfamily {
+    'redhat': { $package = 'gitosis' }
+    default: {fail("OS family ${::osfamily} not supported!")}
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,8 +8,6 @@
 # Sample Usage:
 #  class { 'git': }
 #
-class git {
-  package { 'git':
-    ensure => installed,
-  }
+class git inherits git::params {
+  package { $package: ensure => installed, }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,7 @@
+class git::params() {
+  case $::osfamily {
+    'redhat','debian': { $package = 'git' }
+    'suse': { $package = 'git-core' }
+    default: {fail("OS family ${::osfamily} not supported!")}
+  }
+}


### PR DESCRIPTION
- git::params w/ support for SuSE (git-core).
- limit gitosis to ::osfamily redhat.
