### PR TITLE
Add user support for git configuration

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,11 +1,71 @@
+# == Define: git::config
+#
+# Used to configure git
+#
+# === Parameters
+#
+# [*value*]
+#   The config value. Example: Mike Color or john.doe@example.com.
+#   See examples below.
+#
+# [*section*]
+#   The configuration section. Example: user.
+#   By default extracted from the resource name.
+#
+# [*key*]
+#   The configuration key. Example: email.
+#   By default extracted from the resource name.
+#
+# [*user*]
+#   The user for which the config will be set. Default value: root
+#
+# === Examples
+#
+# Provide some examples on how to use this type:
+#
+#   git::config { 'user.name':
+#     value => 'John Doe',
+#   }
+#
+#   git::config { 'user.email':
+#     value => 'john.doe@example.com',
+#   }
+#
+#   git::config { 'user.name':
+#     value   => 'Mike Color',
+#     user    => 'vagrant',
+#     require => Class['git'],
+#   }
+#
+# === Authors
+#
+# === Copyright
+#
 define git::config(
   $value,
   $section  = regsubst($name, '^([^\.]+)\.([^\.]+)$','\1'),
   $key      = regsubst($name, '^([^\.]+)\.([^\.]+)$','\2'),
+  $user     = 'root',
 ) {
-  exec{"git config --global ${section}.${key} '${value}'":
-    environment => inline_template('<%= "HOME=" + ENV["HOME"] %>'),
-    path        => ['/usr/bin', '/bin'],
-    unless      => "git config --global --get ${section}.${key} '${value}'",
+  if $user == 'root' {
+    # If the command should be executed as root
+
+    exec{"git config --global ${section}.${key} '${value}'":
+      environment => inline_template('<%= "HOME=" + ENV["HOME"] %>'),
+      path        => ['/usr/bin', '/bin'],
+      unless      => "git config --global --get ${section}.${key} '${value}'",
+    }
+
+  } else {
+    # If the command should be executed as non root user
+    #
+    # The .giconfig will be created in /home/$user
+
+    exec{"su - ${user} -c \"git config --global ${section}.${key} '${value}'\"":
+      environment => inline_template('<%= "HOME=" + ENV["HOME"] %>'),
+      path        => ['/usr/bin', '/bin'],
+      unless      => "su - ${user} -c \"git config --global --get ${section}.${key} '${value}'\"",
+    }
+
   }
 }


### PR DESCRIPTION
I tried to configure git for my vagrant user but it was impossible.
Instead the `.gitconfig` was saved for the root user:

```
# Before provisioning
root@webserver:/home/vagrant# ls -al ~
total 24
drwx------  3 root root 4096 Mar 12 17:35 .
drwxr-xr-x 30 root root 4096 Mar 12 16:07 ..
-rw-------  1 root root  289 Mar 12 17:45 .bash_history
-rw-r--r--  1 root root 3106 Jul  3  2012 .bashrc
drwxrwxr-x  3 root root 4096 Mar 12 16:07 .gem
-rw-r--r--  1 root root  140 Jul  3  2012 .profile
# After provisioning
root@webserver:/home/vagrant# ls -al ~
total 28
drwx------  3 root root 4096 Mar 12 17:45 .
drwxr-xr-x 30 root root 4096 Mar 12 16:07 ..
-rw-------  1 root root  289 Mar 12 17:45 .bash_history
-rw-r--r--  1 root root 3106 Jul  3  2012 .bashrc
drwxrwxr-x  3 root root 4096 Mar 12 16:07 .gem
-rw-r--r--  1 root root   94 Mar 12 17:45 .gitconfig
-rw-r--r--  1 root root  140 Jul  3  2012 .profile
```

I used a similar configuration to [this one](https://github.com/czerasz/vagrant-presentation-vm/blob/master/provisioners/puppet/modules/profile/manifests/base.pp#L15-l23)

After the change I can set the config for a particular user:

```
git::config { 'user.name':
  value   => 'Mike Color',
  require => Class['git'],
  user    => 'vagrant',
}

git::config { 'user.email':
  value   => 'email@example.com',
  require => Class['git'],
  user    => 'vagrant',
}
```
