### PR TITLE
Add support for SLES 11

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,15 @@
 #  class { 'git': }
 #
 class git {
-  package { 'git':
-    ensure => installed,
+
+  case $::operatingsystem {
+    /(?ix:sles)/: {
+      include git::sles-git-from-source
+    }
+    default : {
+      package { 'git':
+        ensure => installed,
+      }
+    }
   }
 }

--- a/manifests/sles-git-from-source.pp
+++ b/manifests/sles-git-from-source.pp
@@ -2,12 +2,14 @@ class git::sles-git-from-source (
   $tmp_dir = '/tmp',
   $git_sha1 = 'e60667fc16e5a5f1cde46616b0458cc802707743',
   $git_md5 = undef,
-  $git_filename = 'git-1.9.0.tar.gz',
+  $git_filename = "${git_dirname}.tar.gz",
+  $git_dirname = 'git-1.9.0',
   $git_website = 'http://git-core.googlecode.com/files',
   $zlib_md5 = '44d667c142d7cda120332623eab69f40',
   $zlib_sha1 = undef,
-  $zlib_filename = 'zlib-1.2.8.tar.gz',
-  $zlib_website = 'http://downloads.sourceforge.net/project/libpng/zlib/1.2.8'
+  $zlib_filename = "${zlib_dirname}.tar.gz",
+  $zlib_dirname = 'zlib-1.2.8',
+  $zlib_website = 'http://downloads.sourceforge.net/project/libpng/zlib/1.2.8',
 ){
 
   package { ['openssl', 'wget', 'make', 'autoconf', 'gcc', 'zlib', 'gettext-runtime']:
@@ -51,5 +53,17 @@ class git::sles-git-from-source (
     website => $zlib_website,
     filename => $zlib_filename,
     md5 => $zlib_md5,
+  }
+
+  exec { 'install zlib':
+    command => "cd ${tmp_dir} && tar xzf ${zlib_filename} && cd ${zlib_dirname} && ./configure && make && make install",
+    provider => 'shell',
+    require => [ Wget_and_check[ 'git', 'zlib' ], Package['make', 'autoconf', 'gcc', 'zlib', 'gettext-runtime']],
+  }
+
+  exec { 'install git':
+    command => "cd ${tmp_dir} && tar xzf ${git_filename} && cd ${git_dirname} && ./configure --prefix=/usr && make all && make install",
+    provider => 'shell',
+    require => Exec['install zlib'],
   }
 }


### PR DESCRIPTION
Added a dedicated class which downloads, checks and installs git and zlib from sources as long as those softwares are not present in SLES default repositories. Using the sles sdk iso/dvd or opensuse repositories are not valid alternatives to my eyes (but maybe it's not shared by everyone). Tested on SLES 11 SP3.
