### PR TITLE
Added Class['git'] requirement to git::config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,7 @@ define git::config(
   $key      = regsubst($name, '^([^\.]+)\.([^\.]+)$','\2'),
 ) {
   exec{"git config --global ${section}.${key} '${value}'":
+    require     => Class['git'],
     environment => inline_template('<%= "HOME=" + ENV["HOME"] %>'),
     path        => ['/usr/bin', '/bin'],
     unless      => "git config --global --get ${section}.${key} '${value}'",


### PR DESCRIPTION
Does it make sense to require git before executing the git command?

Without this, I am getting `Could not find command 'git'` the first time I provision. The second time I provision, it works.

Do I need to put a require statement on every single call to `git::config`, or can we add it here?