### PR TITLE
Allow ability to specify a package name.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,8 +8,8 @@
 # Sample Usage:
 #  class { 'git': }
 #
-class git {
-  package { 'git':
+class git ($package_name = 'git') {
+  package { $package_name:
     ensure => installed,
   }
 }


### PR DESCRIPTION
Allow ability to specify a package name. Useful for CentOS where git defaults to 1.7.x and the git18 package is available to install 1.8.x
