### PR TITLE
Allow ability to specify the scope to apply in a config change: global or system

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ git::config { 'user.email':
 
 ###Resources
 
-* `git::config`: Set git global configuration for the user running puppet, or else for the specified `$user`.
+* `git::config`: Set git global configuration for the user running puppet, for the specified `$user` or for the system.
 
 ###Facts
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,6 +37,13 @@
 #     require => Class['git'],
 #   }
 #
+#   git::config { 'http.sslCAInfo':
+#     value   => $companyCAroot,
+#     user    => 'root',
+#     scope   => 'system',
+#     require => Company::Certificate['companyCAroot'],
+#   }
+#
 # === Authors
 #
 # === Copyright
@@ -46,11 +53,12 @@ define git::config(
   $section  = regsubst($name, '^([^\.]+)\.([^\.]+)$','\1'),
   $key      = regsubst($name, '^([^\.]+)\.([^\.]+)$','\2'),
   $user     = 'root',
+  $scope    = 'global',
 ) {
-  exec{"git config --global ${section}.${key} '${value}'":
+  exec{"git config --${scope} ${section}.${key} '${value}'":
     environment => inline_template('<%= "HOME=" + ENV["HOME"] %>'),
     path        => ['/usr/bin', '/bin', '/usr/local/bin'],
     user        => $user,
-    unless      => "git config --global --get ${section}.${key} '${value}'",
+    unless      => "git config --${scope} --get ${section}.${key} '${value}'",
   }
 }


### PR DESCRIPTION
With this change you can define the scope where apply the config change. Sometimes it's better to apply the change in the system instead of one defined user.
