### PR TITLE
Git::config allows scope definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ git::config { 'user.email':
 
 ###Resources
 
-* `git::config`: Set git global configuration for the user running puppet, or else for the specified `$user`.
+* `git::config`: Set git global configuration for the user running puppet, for the specified `$user` or for the system.
 
 ###Facts
 

--- a/lib/puppet/provider/git_config/git_config.rb
+++ b/lib/puppet/provider/git_config/git_config.rb
@@ -7,10 +7,11 @@ Puppet::Type.type(:git_config).provide(:git_config) do
     user    = @property_hash[:user]    = @resource[:user]
     key     = @property_hash[:key]     = @resource[:key]
     section = @property_hash[:section] = @resource[:section]
+    scope   = @property_hash[:scope]   = @resource[:scope]
     home    = Etc.getpwnam(user)[:dir]
 
     current = Puppet::Util::Execution.execute(
-      "git config --global --get #{section}.#{key}",
+      "git config --#{scope} --get #{section}.#{key}",
       :uid => user,
       :failonfail => false,
       :custom_environment => { 'HOME' => home }
@@ -24,10 +25,11 @@ Puppet::Type.type(:git_config).provide(:git_config) do
     user    = @resource[:user]
     key     = @resource[:key]
     section = @resource[:section]
+    scope   = @resource[:scope]
     home    = Etc.getpwnam(user)[:dir]
 
     Puppet::Util::Execution.execute(
-      "git config --global #{section}.#{key} '#{value}'",
+      "git config --#{scope} #{section}.#{key} '#{value}'",
       :uid => user,
       :failonfail => true,
       :custom_environment => { 'HOME' => home }

--- a/lib/puppet/type/git_config.rb
+++ b/lib/puppet/type/git_config.rb
@@ -18,6 +18,13 @@ Puppet::Type.newtype(:git_config) do
      user    => 'vagrant',
      require => Class['git'],
    }
+   
+   git_config { 'http.sslCAInfo':
+     value   => $companyCAroot,
+     user    => 'root',
+     scope   => 'system',
+     require => Company::Certificate['companyCAroot'],
+   }
   DOC
 
   validate do
@@ -43,6 +50,11 @@ Puppet::Type.newtype(:git_config) do
 
   newparam(:key, :namevar => true) do
     desc "The configuration key. Example: email."
+  end
+
+  newparam(:scope) do
+    desc "The scope of the configuration, can be system or global. Default value: global"
+    defaultto "global"
   end
 
   # taken from augeasproviders

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,6 +19,10 @@
 # [*user*]
 #   The user for which the config will be set. Default value: root
 #
+# [*scope*]
+#   The scope of the configuration, can be system or global.
+#   Default value: global
+#
 # === Examples
 #
 # Provide some examples on how to use this type:
@@ -37,6 +41,13 @@
 #     require => Class['git'],
 #   }
 #
+#  git::config { 'http.sslCAInfo':
+#     value   => $companyCAroot,
+#     user    => 'root',
+#     scope   => 'system',
+#     require => Company::Certificate['companyCAroot'],
+#   }
+#
 # === Authors
 #
 # === Copyright
@@ -46,11 +57,13 @@ define git::config (
   $section  = regsubst($name, '^([^\.]+)\.([^\.]+)$','\1'),
   $key      = regsubst($name, '^([^\.]+)\.([^\.]+)$','\2'),
   $user     = 'root',
+  $scope    = 'global',
 ) {
   git_config { $title:
     section => $section,
     key     => $key,
     value   => $value,
     user    => $user,
+    scope   => $scope,
   }
 }


### PR DESCRIPTION
It's the same functionality I added in: https://github.com/puppetlabs/puppetlabs-git/pull/31
But after the merge of https://github.com/puppetlabs/puppetlabs-git/pull/32 it needed to be redone.

I know the "spec/defines/git_config_spec.rb" is failing, but it was failing before my pull request as well.
