### PR TITLE
Don't spit errors on windows

### DIFF
--- a/lib/facter/git_exec_path.rb
+++ b/lib/facter/git_exec_path.rb
@@ -1,4 +1,10 @@
 # git_exec_path.rb
 Facter.add('git_exec_path') do
-  setcode 'git --exec-path 2>/dev/null'
+  case Facter.value(:osfamily)
+  when 'windows'
+    setcode 'git --exec-path 2>nul'
+  else
+    setcode 'git --exec-path 2>/dev/null'
+  end
 end
+

--- a/lib/facter/git_html_path.rb
+++ b/lib/facter/git_html_path.rb
@@ -1,4 +1,10 @@
 # git_html_path.rb
 Facter.add('git_html_path') do
-  setcode 'git --html-path 2>/dev/null'
+  case Facter.value(:osfamily)
+  when 'windows'
+    setcode 'git --html-path 2>nul'
+  else
+    setcode 'git --html-path 2>/dev/null'
+  end
 end
+


### PR DESCRIPTION
The stderr redirection to `/dev/null` makes windows emit errors on every
single facter/puppet run. This simply redirects to `nul` instead when
running on windows family.
