### PR TITLE
Take whole key in $key instead of $section and $key

### DIFF
--- a/lib/puppet/provider/git_config/git_config.rb
+++ b/lib/puppet/provider/git_config/git_config.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:git_config).provide(:git_config) do
     home    = Etc.getpwnam(user)[:dir]
 
     # Backwards compatibility with deprecated $section parameter.
-    if section && !section.empty? && section != :absent
+    if section && !section.empty?
       key = "#{section}.#{key}"
     end
 
@@ -34,7 +34,7 @@ Puppet::Type.type(:git_config).provide(:git_config) do
     home    = Etc.getpwnam(user)[:dir]
 
     # Backwards compatibility with deprecated $section parameter.
-    if section && !section.empty? && section != :absent
+    if section && !section.empty?
       key = "#{section}.#{key}"
     end
 

--- a/lib/puppet/provider/git_config/git_config.rb
+++ b/lib/puppet/provider/git_config/git_config.rb
@@ -10,8 +10,13 @@ Puppet::Type.type(:git_config).provide(:git_config) do
     scope   = @property_hash[:scope]   = @resource[:scope]
     home    = Etc.getpwnam(user)[:dir]
 
+    # Backwards compatibility with deprecated $section parameter.
+    if section && !section.empty? && section != :absent
+      key = "#{section}.#{key}"
+    end
+
     current = Puppet::Util::Execution.execute(
-      "git config --#{scope} --get #{section}.#{key}",
+      "git config --#{scope} --get #{key}",
       :uid => user,
       :failonfail => false,
       :custom_environment => { 'HOME' => home }
@@ -28,8 +33,13 @@ Puppet::Type.type(:git_config).provide(:git_config) do
     scope   = @resource[:scope]
     home    = Etc.getpwnam(user)[:dir]
 
+    # Backwards compatibility with deprecated $section parameter.
+    if section && !section.empty? && section != :absent
+      key = "#{section}.#{key}"
+    end
+
     Puppet::Util::Execution.execute(
-      "git config --#{scope} #{section}.#{key} '#{value}'",
+      "git config --#{scope} #{key} '#{value}'",
       :uid => user,
       :failonfail => true,
       :custom_environment => { 'HOME' => home }

--- a/lib/puppet/type/git_config.rb
+++ b/lib/puppet/type/git_config.rb
@@ -29,10 +29,8 @@ Puppet::Type.newtype(:git_config) do
 
   validate do
     fail('it is required to pass "value"') if self[:value].nil? || self[:value].empty? || self[:value] == :absent
-  end
-
-  newparam(:name) do
-    desc "The default namevar"
+    warning('Parameter `section` is deprecated, supply the full option name (e.g. "user.email") in the `key` parameter') if
+      self[:section] && !self[:section].empty? && self[:section] != :absent
   end
 
   newproperty(:value) do
@@ -44,37 +42,18 @@ Puppet::Type.newtype(:git_config) do
     defaultto "root"
   end
 
-  newparam(:section, :namevar => true) do
-    desc "The configuration section. Example: user."
+  newparam(:key, :namevar => true) do
+    desc "The configuration key. Example: user.email."
   end
 
-  newparam(:key, :namevar => true) do
-    desc "The configuration key. Example: email."
+  newparam(:section) do
+    desc "Deprecated: the configuration section. For example, to set user.email, use section => \"user\", key => \"email\"."
+    defaultto :absent
   end
 
   newparam(:scope) do
     desc "The scope of the configuration, can be system or global. Default value: global"
     defaultto "global"
-  end
-
-  # taken from augeasproviders
-  def self.title_patterns
-    [
-      [
-        /^(([^\.]+)\.([^\.]+))$/,
-        [
-          [ :name ],
-          [ :section ],
-          [ :key ],
-        ]
-      ],
-      [
-        /(.*)/,
-        [
-          [ :name ],
-        ]
-      ]
-    ]
   end
 
 end

--- a/lib/puppet/type/git_config.rb
+++ b/lib/puppet/type/git_config.rb
@@ -30,7 +30,7 @@ Puppet::Type.newtype(:git_config) do
   validate do
     fail('it is required to pass "value"') if self[:value].nil? || self[:value].empty? || self[:value] == :absent
     warning('Parameter `section` is deprecated, supply the full option name (e.g. "user.email") in the `key` parameter') if
-      self[:section] && !self[:section].empty? && self[:section] != :absent
+      self[:section] && !self[:section].empty?
   end
 
   newproperty(:value) do
@@ -48,7 +48,7 @@ Puppet::Type.newtype(:git_config) do
 
   newparam(:section) do
     desc "Deprecated: the configuration section. For example, to set user.email, use section => \"user\", key => \"email\"."
-    defaultto :absent
+    defaultto ""
   end
 
   newparam(:scope) do

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,13 +8,9 @@
 #   The config value. Example: Mike Color or john.doe@example.com.
 #   See examples below.
 #
-# [*section*]
-#   The configuration section. Example: user.
-#   By default extracted from the resource name.
-#
 # [*key*]
-#   The configuration key. Example: email.
-#   By default extracted from the resource name.
+#   The name of the option to be set. Example: user.email.
+#   Default value: same as resource name.
 #
 # [*user*]
 #   The user for which the config will be set. Default value: root
@@ -54,14 +50,22 @@
 #
 define git::config (
   $value,
-  $section  = regsubst($name, '^([^\.]+)\.([^\.]+)$','\1'),
-  $key      = regsubst($name, '^([^\.]+)\.([^\.]+)$','\2'),
+  $key      = $name,
+  $section  = undef,
   $user     = 'root',
   $scope    = 'global',
 ) {
+  # Backwards compatibility with deprecated $section parameter.
+  # (Old versions took separate $section and $key, e.g. "user" and "email".)
+  if $section != undef {
+    warning('Parameter `section` is deprecated, supply the full option name (e.g. "user.email") in the `key` parameter')
+    $_key = "${section}.${key}"
+  } else {
+    $_key = $key
+  }
+
   git_config { $title:
-    section => $section,
-    key     => $key,
+    key     => $_key,
     value   => $value,
     user    => $user,
     scope   => $scope,

--- a/spec/defines/git_config_spec.rb
+++ b/spec/defines/git_config_spec.rb
@@ -11,8 +11,7 @@ describe 'git::config', :type => :define do
     it do
       should contain_git_config('user.name').with(
         'value'   => 'JC Denton',
-        'section' => 'user',
-        'key'     => 'name',
+        'key'     => 'user.name',
         'user'    => 'root'
       )
       have_git_config_resource_count(1)
@@ -29,8 +28,7 @@ describe 'git::config', :type => :define do
     it do
       should contain_git_config('user.email').with(
         'value'   => 'jcdenton@UNATCO.com',
-        'section' => 'user',
-        'key'     => 'email',
+        'key'     => 'user.email',
         'user'    => 'admin'
       )
       have_git_config_resource_count(1)


### PR DESCRIPTION
`git::config` splits `$name` into `$section` and `$key`, only to join them again in `git_config`. This works incorrectly when there's more than one dot in the full name of the key (e.g. `git-up.rebase.auto`).

This pull request fixes this and simplifies the code by making `git_config` and `git::config` take a single `$key` parameter instead of `$key` and `$section`. The change is backward compatible: `git::config` changes its behavior when it receives `$section`.