### PR TITLE
Use ensure_packages to install package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,5 @@
 #  class { 'git': }
 #
 class git ($package_name = 'git') {
-  package { $package_name:
-    ensure => installed,
-  }
+  ensure_packages([ $package_name ])
 }


### PR DESCRIPTION
To avoid a "duplicate definition" on this common package, use the ensure_packages from:
https://github.com/puppetlabs/puppetlabs-stdlib
