### PR TITLE
Fixes fact when git not present

### DIFF
--- a/lib/facter/git_version.rb
+++ b/lib/facter/git_version.rb
@@ -14,7 +14,7 @@ Facter.add('git_version') do
   git_version_cmd = 'git --version 2>&1'
   git_version_result = Facter::Util::Resolution.exec(git_version_cmd)
   setcode do
-    git_version_result.to_s.lines.first.strip.split(/version/)[1].strip
+    git_version_result.to_s.lines.first.strip.split(/version/)[1].strip unless git_version_result.nil?
   end
 end
 


### PR DESCRIPTION
```
Could not retrieve fact='git_version', resolution='<anonymous>': undefined method `strip' for nil:NilClass
```