### PR TITLE
Adding $package_ensure parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,8 +8,11 @@
 # Sample Usage:
 #  class { 'git': }
 #
-class git ($package_name = 'git') {
+class git (
+  $package_name   = 'git',
+  $package_ensure = 'installed'
+) {
   package { $package_name:
-    ensure => installed,
+    ensure => $package_ensure,
   }
 }


### PR DESCRIPTION
To be consistent with other puppetlabs puppet modules, I've added a $package_ensure parameter to the class, in lieu of using ensure_packages.