### PR TITLE
Adding if-not-defined to package definition

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,9 @@
 #  class { 'git': }
 #
 class git ($package_name = 'git') {
-  package { $package_name:
-    ensure => installed,
+  if ! defined(Package[$package_name]) {
+    package { $package_name:
+      ensure => installed,
+    }
   }
 }


### PR DESCRIPTION
This module is often a dependency in other module, and can often conflict with other modules declaration of the relatively common declaration of package named 'git' by adding if ! defined it should make this module a bit friendlier when mixing and matching modules.

```Shell
Warning: Config file /etc/puppet/hiera.yaml not found, using Hiera defaults
Error: Duplicate declaration: Package[git] is already declared in file /vagrant/modules/stash/manifests/install.pp:52; cannot redeclare at /vagrant/modules/git/manifests/init.pp:14 on node vagrant.dev
Error: Duplicate declaration: Package[git] is already declared in file /vagrant/modules/stash/manifests/install.pp:52; cannot redeclare at /vagrant/modules/git/manifests/init.pp:14 on node vagrant.dev
```