### PR TITLE
Fix git_version fact spec test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,16 @@ matrix:
   fast_finish: true
   include:
   - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 1.0"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 2.0"
   - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 1.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 2.0"
   - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 1.0"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 2.0"
 notifications:
   email: false

--- a/lib/facter/git_version.rb
+++ b/lib/facter/git_version.rb
@@ -10,11 +10,11 @@
 #
 # Notes:
 #   None
-if Facter::Util::Resolution.which('git')
-  Facter.add('git_version') do
-    git_version_cmd = 'git --version 2>&1'
-    git_version_result = Facter::Util::Resolution.exec(git_version_cmd)
-    setcode do
+Facter.add('git_version') do
+  setcode do
+    if Facter::Util::Resolution.which('git')
+      git_version_cmd = 'git --version 2>&1'
+      git_version_result = Facter::Util::Resolution.exec(git_version_cmd)
       git_version_result.to_s.lines.first.strip.split(/version/)[1].strip
     end
   end

--- a/spec/unit/facter/git_version_spec.rb
+++ b/spec/unit/facter/git_version_spec.rb
@@ -10,7 +10,7 @@ describe Facter::Util::Fact do
       it do
         git_version_output = 'git version 2.1.2'
         Facter::Util::Resolution.expects(:exec).with("git --version 2>&1").returns(git_version_output)
-        Facter.fact(:git_version).value.should == "2.1.2"
+        Facter.value(:git_version).should == "2.1.2"
       end
     end
 
@@ -21,14 +21,14 @@ git version 2.1.2
 hub version 1.12.2
         EOS
         Facter::Util::Resolution.expects(:exec).with("git --version 2>&1").returns(git_version_output)
-        Facter.fact(:git_version).value.should == "2.1.2"
+        Facter.value(:git_version).should == "2.1.2"
       end
     end
 
     context 'no git present' do
       it do
         Facter::Util::Resolution.expects(:which).with("git").returns(false)
-        Facter.fact(:git_version).should be_nil
+        Facter.value(:git_version).should be_nil
       end
     end
   end


### PR DESCRIPTION
The test for the `git_version` fact where git was not present would cause test failures for Facter 1.x. This refactors the fact to be more testable and fixes the test to work properly. Additionally, since the failures did not occur with Facter 2.x, this extends the Travis build matrix to include both environments with Facter 1.x and environments with Facter 2.x.

Note that this pull request does not solve the issue of building under Ruby 1.8.7.