### PR TITLE
Improve testability and Travis builds (Ruby 1.8.7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,16 @@ matrix:
   fast_finish: true
   include:
   - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 1.0"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 2.0"
   - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 1.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 2.0"
   - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 1.0"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 2.0"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: ruby
-bundler_args: --without development
+bundler_args: --without development system_tests
 script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
 matrix:
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,25 +1,50 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
+def location_for(place, fake_version = nil)
+  if place =~ /^(git:[^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place, { :require => false }]
+  end
+end
+
+is_ruby18 = RUBY_VERSION.start_with? '1.8'
+
 group :development, :test do
   gem 'rake',                    :require => false
+  if is_ruby18
+    gem 'rspec', "~> 3.1.0",     :require => false
+  end
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
-  gem 'serverspec',              :require => false
   gem 'puppet-lint',             :require => false
-  gem 'beaker',                  :require => false
-  gem 'beaker-rspec',            :require => false
   gem 'pry',                     :require => false
   gem 'simplecov',               :require => false
 end
 
-if facterversion = ENV['FACTER_GEM_VERSION']
-  gem 'facter', facterversion, :require => false
+beaker_version = ENV['BEAKER_VERSION']
+group :system_tests do
+  gem 'serverspec',              :require => false
+  if beaker_version
+    gem 'beaker', *location_for(beaker_version)
+  else
+    gem 'beaker',                :require => false
+  end
+  gem 'beaker-rspec',            :require => false
+end
+
+facter_version = ENV['FACTER_GEM_VERSION']
+if facter_version
+  gem 'facter', *location_for(facter_version)
 else
   gem 'facter', :require => false
 end
 
-if puppetversion = ENV['PUPPET_GEM_VERSION']
-  gem 'puppet', puppetversion, :require => false
+puppet_version = ENV['PUPPET_GEM_VERSION']
+if puppet_version
+  gem 'puppet', *location_for(puppet_version)
 else
   gem 'puppet', :require => false
 end

--- a/lib/facter/git_version.rb
+++ b/lib/facter/git_version.rb
@@ -10,11 +10,11 @@
 #
 # Notes:
 #   None
-if Facter::Util::Resolution.which('git')
-  Facter.add('git_version') do
-    git_version_cmd = 'git --version 2>&1'
-    git_version_result = Facter::Util::Resolution.exec(git_version_cmd)
-    setcode do
+Facter.add('git_version') do
+  setcode do
+    if Facter::Util::Resolution.which('git')
+      git_version_cmd = 'git --version 2>&1'
+      git_version_result = Facter::Util::Resolution.exec(git_version_cmd)
       git_version_result.to_s.lines.first.strip.split(/version/)[1].strip
     end
   end

--- a/spec/defines/git_config_spec.rb
+++ b/spec/defines/git_config_spec.rb
@@ -13,7 +13,7 @@ describe 'git::config', :type => :define do
         'value'   => 'JC Denton',
         'section' => 'user',
         'key'     => 'name',
-        'user'    => 'root',
+        'user'    => 'root'
       )
       have_git_config_resource_count(1)
     end
@@ -31,7 +31,7 @@ describe 'git::config', :type => :define do
         'value'   => 'jcdenton@UNATCO.com',
         'section' => 'user',
         'key'     => 'email',
-        'user'    => 'admin',
+        'user'    => 'admin'
       )
       have_git_config_resource_count(1)
     end

--- a/spec/unit/facter/git_version_spec.rb
+++ b/spec/unit/facter/git_version_spec.rb
@@ -10,7 +10,7 @@ describe Facter::Util::Fact do
       it do
         git_version_output = 'git version 2.1.2'
         Facter::Util::Resolution.expects(:exec).with("git --version 2>&1").returns(git_version_output)
-        Facter.fact(:git_version).value.should == "2.1.2"
+        Facter.value(:git_version).should == "2.1.2"
       end
     end
 
@@ -21,14 +21,14 @@ git version 2.1.2
 hub version 1.12.2
         EOS
         Facter::Util::Resolution.expects(:exec).with("git --version 2>&1").returns(git_version_output)
-        Facter.fact(:git_version).value.should == "2.1.2"
+        Facter.value(:git_version).should == "2.1.2"
       end
     end
 
     context 'no git present' do
       it do
         Facter::Util::Resolution.expects(:which).with("git").returns(false)
-        Facter.fact(:git_version).should be_nil
+        Facter.value(:git_version).should be_nil
       end
     end
   end


### PR DESCRIPTION
This uses the patterns used in puppetlabs-stdlib to simplify testing with different versions of various gems and fix Travis builds on Ruby 1.8.7.  It builds off of #54, so merge that first.