### PR TITLE
move to / before issuing the git commands

### DIFF
--- a/lib/puppet/provider/git_config/git_config.rb
+++ b/lib/puppet/provider/git_config/git_config.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:git_config).provide(:git_config) do
     end
 
     current = Puppet::Util::Execution.execute(
-      "git config --#{scope} --get #{key}",
+      "cd / ; git config --#{scope} --get #{key}",
       :uid => user,
       :failonfail => false,
       :custom_environment => { 'HOME' => home }
@@ -39,7 +39,7 @@ Puppet::Type.type(:git_config).provide(:git_config) do
     end
 
     Puppet::Util::Execution.execute(
-      "git config --#{scope} #{key} '#{value}'",
+      "cd / ; git config --#{scope} #{key} '#{value}'",
       :uid => user,
       :failonfail => true,
       :custom_environment => { 'HOME' => home }


### PR DESCRIPTION
When puppet is run as user root from roots home and git_config changes the settings to another user, the commands will fail.