### PR TITLE
MODULES-1863 - Fix Git Config with multiple users

### DIFF
--- a/lib/puppet/provider/git_config/git_config.rb
+++ b/lib/puppet/provider/git_config/git_config.rb
@@ -19,6 +19,7 @@ Puppet::Type.type(:git_config).provide(:git_config) do
       "git config --#{scope} --get #{key}",
       :uid => user,
       :failonfail => false,
+      :combine => true,
       :custom_environment => { 'HOME' => home }
     )
     @property_hash[:value] = current.strip
@@ -42,6 +43,7 @@ Puppet::Type.type(:git_config).provide(:git_config) do
       "git config --#{scope} #{key} '#{value}'",
       :uid => user,
       :failonfail => true,
+      :combine => true,
       :custom_environment => { 'HOME' => home }
     )
   end

--- a/lib/puppet/provider/git_config/git_config.rb
+++ b/lib/puppet/provider/git_config/git_config.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:git_config).provide(:git_config) do
     end
 
     current = Puppet::Util::Execution.execute(
-      "git config --#{scope} --get #{key}",
+      "cd / ; git config --#{scope} --get #{key}",
       :uid => user,
       :failonfail => false,
       :combine => true,
@@ -40,7 +40,7 @@ Puppet::Type.type(:git_config).provide(:git_config) do
     end
 
     Puppet::Util::Execution.execute(
-      "git config --#{scope} #{key} '#{value}'",
+      "cd / ; git config --#{scope} #{key} '#{value}'",
       :uid => user,
       :failonfail => true,
       :combine => true,

--- a/lib/puppet/type/git_config.rb
+++ b/lib/puppet/type/git_config.rb
@@ -18,7 +18,7 @@ Puppet::Type.newtype(:git_config) do
      user    => 'vagrant',
      require => Class['git'],
    }
-   
+
    git_config { 'http.sslCAInfo':
      value   => $companyCAroot,
      user    => 'root',
@@ -33,6 +33,10 @@ Puppet::Type.newtype(:git_config) do
       self[:section] && !self[:section].empty?
   end
 
+  newparam(:name, :namevar => true) do
+    desc "The name of the config"
+  end
+
   newproperty(:value) do
     desc "The config value. Example Mike Color or john.doe@example.com"
   end
@@ -42,8 +46,12 @@ Puppet::Type.newtype(:git_config) do
     defaultto "root"
   end
 
-  newparam(:key, :namevar => true) do
+  newparam(:key) do
     desc "The configuration key. Example: user.email."
+  end
+
+  autorequire(:user) do
+    self[:user]
   end
 
   newparam(:section) do

--- a/spec/acceptance/git_config_different_users_spec.rb
+++ b/spec/acceptance/git_config_different_users_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper_acceptance'
+
+describe 'git::config class' do
+
+  context 'with some user settings' do
+    it 'should work idempotently with no errors' do
+      pp = <<-EOS
+      package { 'git': }
+      ->
+      git::config { 'Root User Email':
+        key   => 'user.email',
+        value => 'john.doe@example.com',
+      }
+      ->
+      user { 'janedoe':
+        ensure      => 'present',
+        managehome  => true,
+      }
+      ->
+      file { '/home/janedoe/.gitconfig':
+        ensure   => 'present',
+      }
+      ->
+      git::config { 'Jane User Email':
+        key   => 'user.email',
+        user  => 'janedoe',
+        value => 'jane.doe@example.com',
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
+    end
+
+    describe file('/home/janedoe/.gitconfig') do
+      its(:content) { should match /email = jane.doe@example.com/ }
+    end
+
+    describe file('/root/.gitconfig') do
+      its(:content) { should match /email = john.doe@example.com/ }
+    end
+  end
+end

--- a/spec/unit/puppet/provider/git_config/git_config_spec.rb
+++ b/spec/unit/puppet/provider/git_config/git_config_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:git_config).provider(:git_config) do
+
+  let(:resource) { Puppet::Type.type(:git_config).new(
+    {
+    :key       => 'user.email',
+    :value     => 'john.doe@example.com',
+    }
+  )}
+
+  let(:provider) { resource.provider }
+
+end

--- a/spec/unit/puppet/type/git_config/git_config_spec.rb
+++ b/spec/unit/puppet/type/git_config/git_config_spec.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+
+require 'spec_helper'
+
+describe Puppet::Type.type(:git_config) do
+
+  before do
+    @class = described_class
+    @provider_class = @class.provide(:fake) { mk_resource_methods }
+    @provider = @provider_class.new
+    @resource = stub 'resource', :resource => nil, :provider => @provider
+
+    @class.stubs(:defaultprovider).returns @provider_class
+    @class.any_instance.stubs(:provider).returns @provider
+  end
+
+  it "should have :name as its keyattribute" do
+    @class.key_attributes.should == [:name]
+  end
+
+  describe "when validating attributes" do
+
+    params = [
+      :name,
+      :user,
+      :key,
+      :section,
+      :scope,
+    ]
+
+    properties = [
+      :value,
+    ]
+
+    params.each do |param|
+      it "should have a #{param} parameter" do
+        @class.attrtype(param).should == :param
+      end
+    end
+
+    properties.each do |property|
+      it "should have a #{property} property" do
+        @class.attrtype(property).should == :property
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
As shown in #59, the git_config provider won't work with non-root users unless you change the cwd.

However, whilst writing the beaker tests for this, I also realised that the current type for `git_config` uses the key for the namevar, it's not possible to have multiple configs for different users using the same key.

This PR changes the namevar to name, cherry picks the commit from @cristi1979, adds Beaker tests to check the behaviour works and adds some basic type and provider specs too.