### PR TITLE
Support flat config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ include git
 
 ```yaml
 git::configs:
-  user.name:
-    value: 'test'
-  user.email:
-    value: 'test@test.com'
+  user.name: 'test'
+  user.email: 'test@example.com'
+  core.filemode:
+    value: false
+    scope: system
 ```
 
 ###I want to use `git subtree` with bash completion

--- a/lib/puppet/parser/functions/git_config_hash.rb
+++ b/lib/puppet/parser/functions/git_config_hash.rb
@@ -1,0 +1,25 @@
+#
+# config_hash.rb
+#
+
+module Puppet::Parser::Functions
+  newfunction(:git_config_hash, :type => :rvalue, :doc => <<-EOS
+This function ensures the proper structure for git configuration options.
+*Examples:*
+    git_config_hash({"foo" => 1, "bar" => {"value" => 2}})
+Would return: {"foo" => {"value" => 1}, "bar" => {"value" => 2}}
+    EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "git_config_hash(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size < 1
+
+    configs = arguments[0]
+
+    unless configs.is_a?(Hash)
+      raise(Puppet::ParseError, 'git_config_hash(): Requires hash to work with')
+    end
+
+    return Hash[configs.map {|k, v| [k, v.is_a?(Hash) ? v : {"value" => v}] }]
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,5 +34,5 @@ class git (
     }
   }
   
-  create_resources(git::config, $configs)
+  create_resources(git::config, git_config_hash($configs))
 }

--- a/spec/classes/git_spec.rb
+++ b/spec/classes/git_spec.rb
@@ -40,10 +40,14 @@ describe 'git' do
   context 'with configs' do
     let(:params) {
       {
-        :configs => {"user.name" => {"value" => "test"}}
+        :configs => {
+          "user.name" => {"value" => "test"},
+          "user.email" => "test@example.com"
+        }
       }
     }
     it { should contain_git__config('user.name') }
+    it { should contain_git__config('user.email') }
   end
 
 end


### PR DESCRIPTION
With a recent change [`git::configs` was added](https://github.com/puppetlabs/puppetlabs-git/commit/1d9cd64941ebe103b30bf4de36ffa1dd5a9a1960). 

With this follow-up a flat configuration like this is now also supported:

```yaml
git::configs:
  user.name: 'test'
  user.email: 'test@example.com'
```