### PR TITLE
Escape git config values

### DIFF
--- a/lib/puppet/provider/git_config/git_config.rb
+++ b/lib/puppet/provider/git_config/git_config.rb
@@ -1,3 +1,5 @@
+require "shellwords"
+
 Puppet::Type.type(:git_config).provide(:git_config) do
 
   mk_resource_methods
@@ -40,7 +42,7 @@ Puppet::Type.type(:git_config).provide(:git_config) do
     end
 
     Puppet::Util::Execution.execute(
-      "cd / ; git config --#{scope} #{key} '#{value}'",
+      "cd / ; git config --#{scope} #{key} #{value.shellescape}",
       :uid => user,
       :failonfail => true,
       :combine => true,


### PR DESCRIPTION
Escape git config values for shell execution. Otherwise e.g. using quotes in aliases will fail.