### PR TITLE
Support defaults for git config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ git::configs:
     scope: system
 ```
 
+If using the flat config syntax, options common to all items can be set:
+
+```yaml
+git::configs:
+  core.filemode: false
+git::configs_defaults:
+  scope: system
+```
+
 ###I want to use `git subtree` with bash completion
 
 ```puppet

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,17 +22,22 @@
 # [*configs*]
 #   hash of configurations as per the git::config defined type
 #
+# [*configs_defaults*]
+#   hash of configuration defaults as per the git::config defined type
+#   to use for every *configs* item
+#
 class git (
   $package_name   = 'git',
   $package_ensure = 'installed',
   $package_manage = true,
-  $configs = {}
+  $configs = {},
+  $configs_defaults = {}
 ) {
   if ( $package_manage ) {
     package { $package_name:
       ensure => $package_ensure,
     }
   }
-  
-  create_resources(git::config, git_config_hash($configs))
+
+  create_resources(git::config, git_config_hash($configs), $configs_defaults)
 }

--- a/spec/classes/git_spec.rb
+++ b/spec/classes/git_spec.rb
@@ -36,7 +36,7 @@ describe 'git' do
       }
     )}
   end
-  
+
   context 'with configs' do
     let(:params) {
       {
@@ -48,6 +48,23 @@ describe 'git' do
     }
     it { should contain_git__config('user.name') }
     it { should contain_git__config('user.email') }
+  end
+
+  context 'with configs and configs defaults' do
+    let(:params) {
+      {
+        :configs => {
+          "core.filemode" => false
+        },
+        :configs_defaults => {
+          "scope" => "system"
+        }
+      }
+    }
+    it { should contain_git__config('core.filemode').with(
+        'value' => false,
+        'scope' => 'system'
+    ) }
   end
 
 end


### PR DESCRIPTION
To complement the flat config this allows for setting defaults for all config items, e.g. scope or user.

This is especially useful if `git::configs_defaults` are set in a `common` Hiera data source and `git::configs` in a specific one.