### PR TITLE
Stop this erroring in Windows machines

### DIFF
--- a/lib/facter/git_version.rb
+++ b/lib/facter/git_version.rb
@@ -11,6 +11,7 @@
 # Notes:
 #   None
 Facter.add('git_version') do
+    confine :kernel => /^(?!windows$)/
   setcode do
     if Facter::Util::Resolution.which('git')
       git_version_cmd = 'git --version 2>&1'


### PR DESCRIPTION
The facter.util.resolution.which doesn't handle spaces well and this was causing the fact to error out. As Windows isn't a supported platform a confine seems the easiest fix.