### PR TITLE
Adding SLES support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ before_install:
 matrix:
   fast_finish: true
   include:
+  - rvm: 2.4.4
+    bundler_args: --without system_tests
+    env: PUPPET_GEM_VERSION="~> 5.0"
   - rvm: 2.3.1
     bundler_args: --without system_tests
     env: PUPPET_GEM_VERSION="~> 4.0"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,12 +27,12 @@
 #   to use for every *configs* item
 #
 class git (
-  $package_name   = 'git',
-  $package_ensure = 'installed',
-  $package_manage = true,
+  $package_name   = $git::params::package_name,
+  $package_ensure = $git::params::package_ensure,
+  $package_manage = $git::params::package_manage,
   $configs = {},
   $configs_defaults = {}
-) {
+) inherits git::params {
   if ( $package_manage ) {
     package { $package_name:
       ensure => $package_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,13 @@
+# Git::params
+#
+#
+class git::params {
+  $package_ensure = 'installed'
+  $package_manage = true
+
+  if $::osfamily == 'Suse' {
+    $package_name   = 'git-core'
+  } else {
+    $package_name   = 'git'
+  }
+}

--- a/manifests/subtree.pp
+++ b/manifests/subtree.pp
@@ -6,7 +6,7 @@ class git::subtree {
 
   include ::git
 
-  Package['git'] -> Class['git::subtree']
+  Class['git'] -> Class['git::subtree']
 
   if (versioncmp('1.7.0', $::git_version) > 0) {
     fail 'git-subtree requires git 1.7 or later!'
@@ -31,12 +31,10 @@ class git::subtree {
     cwd     => $source_dir,
     path    => ['/usr/bin', '/bin', '/usr/local/bin'],
   }
-  ->
-  package { [ 'asciidoc', 'xmlto', ]:
+  -> package { [ 'asciidoc', 'xmlto', ]:
     ensure => present,
   }
-  ->
-  exec { 'Install git-subtree':
+  -> exec { 'Install git-subtree':
     command => "make prefix=/usr libexecdir=${::git_exec_path} install",
     onlyif  => [
       "test ! -f ${::git_exec_path}/git-subtree",

--- a/metadata.json
+++ b/metadata.json
@@ -38,10 +38,16 @@
         "12.04",
         "14.04"
       ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "12"
+      ]
     }
   ],
   "requirements": [
-    {"name":"puppet","version_requirement":">= 3.0.0 < 5.0.0"}
+    {"name":"puppet","version_requirement":">= 3.0.0 < 7.0.0"}
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}

--- a/spec/classes/git_gitosis_spec.rb
+++ b/spec/classes/git_gitosis_spec.rb
@@ -1,10 +1,17 @@
 require 'spec_helper'
 
 describe 'git::gitosis' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
 
-  context 'defaults' do
-    it { should contain_package('gitosis') }
-    it { should contain_class('git') }
-    it { should create_class('git::gitosis') }
+      context 'defaults' do
+        it do
+          should contain_package('gitosis')
+          should contain_class('git')
+          should create_class('git::gitosis')
+        end
+      end
+    end
   end
 end

--- a/spec/classes/git_spec.rb
+++ b/spec/classes/git_spec.rb
@@ -1,70 +1,118 @@
 require 'spec_helper'
 
 describe 'git' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
 
-  context 'defaults' do
-    it { should contain_package('git') }
-  end
+      case os_facts[:osfamily]
+      when 'Suse'
+        context 'defaults' do
+          it do
+            should contain_package('git-core')
+          end
+        end
 
-  context 'with package_manage set to false' do
-    let(:params) {
-      {
-        :package_manage => false,
-      }
-    }
-    it { should_not contain_package('git') }
-  end
+        context 'with package_manage set to false' do
+          let(:params) do
+            {
+              package_manage: false
+            }
+          end
 
-  context 'with a custom git package name' do
-    let(:params) {
-      {
-        :package_name => 'gitolite',
-      }
-    }
-    it { should contain_package('gitolite') }
-  end
+          it do
+            should_not contain_package('git-core')
+          end
+        end
 
-  context 'with package_ensure => latest' do
-    let(:params) {
-      {
-        :package_ensure => 'latest',
-      }
-    }
-    it { should contain_package('git').with(
-      {
-        'ensure' => 'latest'
-      }
-    )}
-  end
+        context 'with package_ensure => latest' do
+          let(:params) do
+            {
+              package_ensure: 'latest'
+            }
+          end
 
-  context 'with configs' do
-    let(:params) {
-      {
-        :configs => {
-          "user.name" => {"value" => "test"},
-          "user.email" => "test@example.com"
+          it do
+            should contain_package('git-core').with(
+              'ensure' => 'latest'
+            )
+          end
+        end
+
+      else
+        context 'defaults' do
+          it { should contain_package('git') }
+        end
+
+        context 'with package_manage set to false' do
+          let(:params) do
+            {
+              package_manage: false
+            }
+          end
+
+          it { should_not contain_package('git') }
+        end
+
+        context 'with a custom git package name' do
+          let(:params) do
+            {
+              package_name: 'gitolite'
+            }
+          end
+
+          it { should contain_package('gitolite') }
+        end
+
+        context 'with package_ensure => latest' do
+          let(:params) do
+            {
+              package_ensure: 'latest'
+            }
+          end
+          it {
+            should contain_package('git').with(
+              'ensure' => 'latest'
+            )
+          }
+        end
+      end
+
+      context 'with configs' do
+        let(:params) do
+          {
+            configs: {
+              'user.name' => { 'value' => 'test' },
+              'user.email' => 'test@example.com'
+            }
+          }
+        end
+
+        it do
+          should contain_git__config('user.name')
+          should contain_git__config('user.email')
+        end
+      end
+
+      context 'with configs and configs defaults' do
+        let(:params) do
+          {
+            configs: {
+              'core.filemode' => false
+            },
+            configs_defaults: {
+              'scope' => 'system'
+            }
+          }
+        end
+
+        it {
+          should contain_git__config('core.filemode').with(
+            'value' => false,
+            'scope' => 'system'
+          )
         }
-      }
-    }
-    it { should contain_git__config('user.name') }
-    it { should contain_git__config('user.email') }
+      end
+    end
   end
-
-  context 'with configs and configs defaults' do
-    let(:params) {
-      {
-        :configs => {
-          "core.filemode" => false
-        },
-        :configs_defaults => {
-          "scope" => "system"
-        }
-      }
-    }
-    it { should contain_git__config('core.filemode').with(
-        'value' => false,
-        'scope' => 'system'
-    ) }
-  end
-
 end

--- a/spec/classes/git_subtree_spec.rb
+++ b/spec/classes/git_subtree_spec.rb
@@ -1,77 +1,91 @@
 require 'spec_helper'
 
 describe 'git::subtree' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      versions = ['1.6.0', '1.7.0', '1.7.11']
 
-  versions = ['1.6.0', '1.7.0', '1.7.11']
-  versions.each do |version|
-    context "when git version is #{version}" do
-    let(:facts) { {
-      :git_version   => version,
-     } }
-      if version < '1.7.0'
-        it 'should fail' do
-          expect { should create_class('git::subtree') }.to raise_error(Puppet::Error, /git-subtree requires git 1.7 or later!/)
+      versions.each do |version|
+        context "when git version is #{version}" do
+          let(:facts) do
+            os_facts.merge(
+              git_version: version
+            )
+          end
+
+          if version < '1.7.0'
+            it 'should fail' do
+              expect { should create_class('git::subtree') }.to raise_error(Puppet::Error, /git-subtree requires git 1.7 or later!/)
+            end
+          else
+            it do
+              should create_class('git::subtree')
+              should contain_class('git')
+              should contain_package('asciidoc')
+              should contain_package('xmlto')
+              should contain_exec('Install git-subtree')
+              should contain_exec('Build git-subtree')
+              should create_file('/etc/bash_completion.d/git-subtree').with(
+                ensure: 'file',
+                source: 'puppet:///modules/git/subtree/bash_completion.sh',
+                mode: '0644'
+              )
+            end
+          end
         end
-      else
-        it { should create_class('git::subtree') }
-        it { should contain_class('git') }
-        it { should contain_package('asciidoc') }
-        it { should contain_package('xmlto') }
-        it { should contain_exec('Install git-subtree') }
-        it { should contain_exec('Build git-subtree') }
+      end
 
-        it { should create_file('/etc/bash_completion.d/git-subtree').with({
-          :ensure => 'file',
-          :source => 'puppet:///modules/git/subtree/bash_completion.sh',
-          :mode   => '0644',
-        })}
+      context 'when git version > 1.7.0 and < 1.7.11' do
+        let(:facts) do
+          os_facts.merge(
+            git_version: '1.7.0',
+            git_exec_path: '/usr/lib/git-core',
+            git_html_path: '/usr/share/doc/git',
+          )
+        end
+
+        it {
+          should create_vcsrepo('/usr/src/git-subtree').with(
+            ensure: 'present',
+            source: 'https://github.com/apenwarr/git-subtree.git',
+            provider: 'git',
+            revision: '2793ee6ba'
+          )
+
+          should create_exec('Build git-subtree').with(
+            command: 'make prefix=/usr libexecdir=/usr/lib/git-core',
+            creates: '/usr/src/git-subtree/git-subtree',
+            cwd: '/usr/src/git-subtree'
+          )
+
+          should create_exec('Install git-subtree').with(
+            command: 'make prefix=/usr libexecdir=/usr/lib/git-core install',
+            cwd: '/usr/src/git-subtree'
+          )
+        }
+      end
+
+      context 'when git version >= 1.7.11' do
+        let(:facts) do
+          os_facts.merge(
+            git_version: '1.7.11',
+            git_exec_path: '/usr/lib/git-core',
+            git_html_path: '/usr/share/doc/git',
+          )
+        end
+
+        it {
+          should create_exec('Build git-subtree').with(
+            creates: '/usr/share/doc/git/contrib/subtree/git-subtree',
+            cwd: '/usr/share/doc/git/contrib/subtree'
+          )
+
+          should create_exec('Install git-subtree').with(
+            command: 'make prefix=/usr libexecdir=/usr/lib/git-core install',
+            cwd: '/usr/share/doc/git/contrib/subtree'
+          )
+        }
       end
     end
   end
-
-  context 'when git version > 1.7.0 and < 1.7.11' do
-    let(:facts) { {
-      :git_version   => '1.7.0',
-      :git_exec_path => '/usr/lib/git-core',
-      :git_html_path => "/usr/share/doc/git"
-    } }
-
-    it { should create_vcsrepo('/usr/src/git-subtree').with({
-      :ensure   => 'present',
-      :source   => 'https://github.com/apenwarr/git-subtree.git',
-      :provider => 'git',
-      :revision => '2793ee6ba',
-    })}
-
-    it { should create_exec('Build git-subtree').with({
-      :command => 'make prefix=/usr libexecdir=/usr/lib/git-core',
-      :creates => '/usr/src/git-subtree/git-subtree',
-      :cwd     => '/usr/src/git-subtree',
-    })}
-
-    it { should create_exec('Install git-subtree').with({
-      :command => 'make prefix=/usr libexecdir=/usr/lib/git-core install',
-      :cwd     => '/usr/src/git-subtree',
-    })}
-  end
-
-  context 'when git version >= 1.7.11' do
-    let(:facts) { {
-      :git_version   => '1.7.11',
-      :git_exec_path => '/usr/lib/git-core',
-      :git_html_path => "/usr/share/doc/git"
-    } }
-
-    it { should create_exec('Build git-subtree').with({
-      :creates => '/usr/share/doc/git/contrib/subtree/git-subtree',
-      :cwd     => '/usr/share/doc/git/contrib/subtree',
-    })}
-
-    it { should create_exec('Install git-subtree').with({
-      :command => 'make prefix=/usr libexecdir=/usr/lib/git-core install',
-      :cwd     => '/usr/share/doc/git/contrib/subtree',
-    })}
-  end
-
-
 end

--- a/spec/defines/git_config_spec.rb
+++ b/spec/defines/git_config_spec.rb
@@ -1,57 +1,62 @@
 require 'spec_helper'
 
-describe 'git::config', :type => :define do
-  context 'has working default parameters' do
-    let(:title) { 'user.name' }
-    let(:params) {
-      {
-        :value => 'JC Denton',
-      }
-    }
-    it do
-      should contain_git_config('user.name').with(
-        'value'   => 'JC Denton',
-        'key'     => 'user.name',
-        'user'    => 'root'
-      )
-      have_git_config_resource_count(1)
-    end
-  end
-  context 'allows you to change user' do
-    let(:title) { 'user.email' }
-    let(:params) {
-      {
-        :value => 'jcdenton@UNATCO.com',
-        :user  => 'admin'
-      }
-    }
-    it do
-      should contain_git_config('user.email').with(
-        'value'   => 'jcdenton@UNATCO.com',
-        'key'     => 'user.email',
-        'user'    => 'admin'
-      )
-      have_git_config_resource_count(1)
-    end
-  end
-  context 'allow boolean values' do
-    let(:title) { 'core.preloadindex' }
-    let(:params) {
-      {
-        :value => true,
-        :scope => 'system',
-      }
-    }
-    it {
-      is_expected.to compile
-    }
-    it {
-      is_expected.to contain_git_config(title).with(
-        {
-          'value' => params[:value],
-          'scope' => params[:scope],
+describe 'git::config', type: :define do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'has working default parameters' do
+        let(:title) { 'user.name' }
+        let(:params) do
+          {
+            value: 'JC Denton'
+          }
+        end
+
+        it do
+          should contain_git_config('user.name').with(
+            'value' => 'JC Denton',
+            'key' => 'user.name',
+            'user' => 'root'
+          )
+          have_git_config_resource_count(1)
+        end
+      end
+      context 'allows you to change user' do
+        let(:title) { 'user.email' }
+        let(:params) do
+          {
+            value: 'jcdenton@UNATCO.com',
+            user: 'admin'
+          }
+        end
+
+        it do
+          should contain_git_config('user.email').with(
+            'value' => 'jcdenton@UNATCO.com',
+            'key' => 'user.email',
+            'user' => 'admin'
+          )
+          have_git_config_resource_count(1)
+        end
+      end
+      context 'allow boolean values' do
+        let(:title) { 'core.preloadindex' }
+        let(:params) do
+          {
+            value: true,
+            scope: 'system'
+          }
+        end
+
+        it {
+          is_expected.to compile
+          is_expected.to contain_git_config(title).with(
+            'value' => params[:value],
+            'scope' => params[:scope]
+          )
         }
-      )
-    }
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+
+include RspecPuppetFacts
 
 RSpec.configure do |config|
   config.hiera_config = 'spec/fixtures/hiera/hiera.yaml'

--- a/spec/unit/puppet/provider/git_config/git_config_spec.rb
+++ b/spec/unit/puppet/provider/git_config/git_config_spec.rb
@@ -1,14 +1,16 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:git_config).provider(:git_config) do
-
-  let(:resource) { Puppet::Type.type(:git_config).new(
-    {
-    :key       => 'user.email',
-    :value     => 'john.doe@example.com',
-    }
-  )}
-
-  let(:provider) { resource.provider }
-
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:resource) do
+        Puppet::Type.type(:git_config).new(
+          key: 'user.email',
+          value: 'john.doe@example.com'
+        )
+      end
+      let(:provider) { resource.provider }
+    end
+  end
 end


### PR DESCRIPTION
A few changes are required to add SLES support:
* SLES uses git-core instead of git as the package name. Moving several paramaters to the params.pp pattern to accomodate.
* Adding support for SLES by fixing the tests that are looking for a static package name.
* Fixing the tests to use OS for Gitosis and subtree
* Changing to require class Git instead of package
* Adding OS information to git::config unit tests.
* Adding OS information to git::config defines tests.
* The chaining arrows need to move to fix syntax error in a test
* Subtree unit test appears to have a syntax error. Correcting by joining lines.