### PR TITLE
Avoid duplicate declarations of Package['git']

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,9 +34,7 @@ class git (
   $configs_defaults = {}
 ) {
   if ( $package_manage ) {
-    package { $package_name:
-      ensure => $package_ensure,
-    }
+    ensure_packages([$package_name], { ensure => $package_ensure })
   }
 
   create_resources(git::config, git_config_hash($configs), $configs_defaults)


### PR DESCRIPTION
Use ensure_packages() to install/remove the package, instead of package{} to avoid
duplicate declaration of Package['git'].