### PR TITLE
Fix errors in tests

### DIFF
--- a/manifests/subtree.pp
+++ b/manifests/subtree.pp
@@ -31,12 +31,10 @@ class git::subtree {
     cwd     => $source_dir,
     path    => ['/usr/bin', '/bin', '/usr/local/bin'],
   }
-  ->
-  package { [ 'asciidoc', 'xmlto', ]:
+  -> package { [ 'asciidoc', 'xmlto', ]:
     ensure => present,
   }
-  ->
-  exec { 'Install git-subtree':
+  -> exec { 'Install git-subtree':
     command => "make prefix=/usr libexecdir=${::git_exec_path} install",
     onlyif  => [
       "test ! -f ${::git_exec_path}/git-subtree",


### PR DESCRIPTION
manifests/subtree.pp - WARNING: arrow should be on the right operand's line on line 34
manifests/subtree.pp - WARNING: arrow should be on the right operand's line on line 38